### PR TITLE
Fix profile center in IE

### DIFF
--- a/assets/scss/components/_aside.scss
+++ b/assets/scss/components/_aside.scss
@@ -27,7 +27,6 @@
 
 .profile {
   max-width: 38.75rem;
-  margin: 0 auto;
 
   > p {
     margin: 0 2rem;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5127501/8125163/8695afb8-10e3-11e5-9df2-4515fe21d93e.png)

This change fixes a bug that makes the profile `<div>` to appear at the right of the screen on **Internet Explorer 11.**
