### PR TITLE
Fixes overflow below 1024px

### DIFF
--- a/assets/scss/components/_media-queries.scss
+++ b/assets/scss/components/_media-queries.scss
@@ -67,7 +67,7 @@
     width: 100%;
     max-width: 100%;
     height: 100%;
-    overflow: scroll;
+    overflow: hidden;
 
     &.contact {
       margin-top: 1rem;


### PR DESCRIPTION
This is what happens in Google Chrome on Windows, when resizing the website below 1024px.
![overflow](https://cloud.githubusercontent.com/assets/5127501/8225506/dc5ec57c-1595-11e5-8d1d-a499304f6ae9.png)
This change fixes this behaviour ^_^
