### PR TITLE
Fixed navigation URLs

### DIFF
--- a/partials/links.hbs
+++ b/partials/links.hbs
@@ -3,7 +3,7 @@
     <li class="links item">
       <a href="{{@blog.url}}/#open" class="link-item" title="{{@blog.title}} blog" id="blog-button">Blog</a>
       {{#foreach @blog.navigation}}
-        <a href="{{url}}" class="link-item" id="{{slug}}-button">{{label}}</a>
+        <a href="{{this.url}}" class="link-item" id="{{slug}}-button">{{label}}</a>
       {{/foreach}}
     </li>
   </ul>


### PR DESCRIPTION
Looks like `{{url}}` attribute is currently overridden by the Ghost's builtin `{{url}}` helper, that causes all navigation links have `href="/"`.
