### PR TITLE
improve scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ One objective of this project is to adopt an effective policy to have the latest
 
 ### Update your current version
 
-Make sure you in the uno-zen directory. Then run
+Make sure you're in the uno-zen directory. Then run
 
 ```bash
 sh scripts/update

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
     + [Whats is new in 2.x](#whats-is-new-in-2x)
   * [Installation](#installation)
   * [Update](#update)
-    + [Receive a mail notification when a new version is available.](#receive-a-mail-notification-when-a-new-version-is-available)
     + [Update your current version](#update-your-current-version)
+    + [Receive a mail notification when a new version is available.](#receive-a-mail-notification-when-a-new-version-is-available)
   * [Development and Customization](#development-and-customization)
   * [Showcase](#showcase)
   * [License](#license)
@@ -62,6 +62,17 @@ $ curl -sSL http://git.io/vcIHr | sh
 
 One objective of this project is to adopt an effective policy to have the latest version of the theme all the time. We have divided this process into two steps:
 
+
+### Update your current version
+
+Make sure you in the uno-zen directory. Then run
+
+```bash
+sh scripts/update
+```
+
+That's all!
+
 ### Receive a mail notification when a new version is available.
 
 Based in a [IFTTT](https://ifttt.com/recipes) recipe, you can subscribe for know the next releases:
@@ -71,12 +82,6 @@ Based in a [IFTTT](https://ifttt.com/recipes) recipe, you can subscribe for know
 </br>
 </br>
 </div>
-
-### Update your current version
-
-Just run the `sh scripts/update` script for do it.
-
-That's all!
 
 ## Development and Customization
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 
 if [ -d "uno-zen" ]; then
   echo "\nUno Zen is already installed. Maybe you want to update? Run:"
-  echo "\nsh scripts/update.sh"
+  echo "\ncd uno-zen && sh scripts/update.sh\n"
   exit
 fi
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -11,7 +11,7 @@ echo "Searching for updates..."
 git fetch --tags origin
 latestTag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
-if [ "$currentVersion" == "$latestTag" ]; then
+if [ "$currentVersion" = "$latestTag" ]; then
   echo "\nYou already have the latest version."
 else
   echo "\nUpdating $currentVersion to $latestTag..."


### PR DESCRIPTION
Using one compare operator is better in shell.
In bash it seems to doesn't matter, but shell throws a error here
`scripts/update.sh: 14: [: 2.5.5: unexpected operator`

switch directories before update
