### PR TITLE
Adding image to tag template

### DIFF
--- a/tag.hbs
+++ b/tag.hbs
@@ -1,6 +1,9 @@
 {{!< default}}
 
-<h1 style="text-align: center;">Tag: {{tag.name}}.</h1>
+{{#tag}}
+<h1 style="text-align: center;">Tag: {{name}}.</h1>
+{{#if image}}<img id="post-image" src="{{image}}" alt="{{{title}}}">{{/if}}
+{{/tag}}
 <ol id="posts-list">
   {{#foreach posts}}
   <li>


### PR DESCRIPTION
Turns out tags can have images now! Stolen the image tag from the post template and replicated here however in the `{{tag}}` context.
