### PR TITLE
Fixed issue with build.sh where it wasn't copying necessary JS files

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -11,7 +11,6 @@
 <a target="blank" href="https://robinz.in"><img src="http://i.imgur.com/qDAbrch.jpg" /></a>
 <a target="blank" href="http://biercoff.com"><img src="http://i.imgur.com/goS3pE3.jpg" /></a>
 <a target="blank" href="https://randy.sesser.me"><img src="http://i.imgur.com/9hacUJc.jpg" /></a>
-<a target="blank" href="http://dan.maharry.me.uk"><img src="http://i.imgur.com/gAeS9jQ.jpg" /></a>
 <a target="blank" href="http://maptime.io/milan/"><img src="http://i.imgur.com/hd9tpzq.jpg" /></a>
 <a target="blank" href="http://xlbd.me"><img src="http://i.imgur.com/wiqVB9R.jpg" /></a>
 <a target="blank" href="http://olddonkey.com"><img src="http://i.imgur.com/wa4kwnZ.jpg" /></a>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 # This script creates an archive of the theme files to be used with Ghost(Pro).
 # Note: Be sure to first run 'Gulp build' before executing this script, to ensure everything is compiled and minified for production.
 
-FILES="*.hbs *.md *.html partials/ assets/js/uno-zen.js assets/css/uno-zen.css assets/fonts/ assets/img/"
+FILES="*.hbs *.md *.html partials/ assets/js/uno-zen.common.js assets/js/uno-zen.post.js assets/css/uno-zen.css assets/fonts/ assets/img/"
 OUTPUT="uno-zen"
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
Build script was trying to copy uno-zen.js, but that doesn't exist in the current version and has been replaced by uno-zen.post.js and uno-zen.common.js.